### PR TITLE
fix code snippets on step 1

### DIFF
--- a/docs/_pages/1.add-sql.md
+++ b/docs/_pages/1.add-sql.md
@@ -137,9 +137,15 @@ specified in our typeDef and requesting that the response columns be named to ma
 ## Generate Safe Queries
 
 <pre><code class="language-javascript">
-// File: src/schema/checkout/checkout.model.js
-const requestedMySQLFields = Object.keys(checkoutTableVariablesMap).map(key => `${checkoutTableVariablesMap[key]} as ${key}`);
-let queryStr = `select ${requestedMySQLFields.join(',')} from checkouts`;
+// File: src/index.js
+const resolvers = {
+  Query: {
+    checkouts: async (root, args) => {
+      const requestedMySQLFields = Object.keys(checkoutTableVariablesMap).map(key => `${checkoutTableVariablesMap[key]} as ${key}`);
+      let queryStr = `select ${requestedMySQLFields.join(',')} from checkouts`;
+      ...
+    },
+  },
 </code></pre>
 
 Our current checkouts query allows for arguments to be sent in order for results to be filtered. We can pass this filter along to MySQL by modifying our query
@@ -147,12 +153,19 @@ to add a WHERE clause in order to reduce load on the database query. Be certain 
 make certain that user passed variables are not being sent directly to your database query in order to prevent SQL injection attacks. For our driver, we are
 using the format method provided by the mysql library.
 
-<pre><code class="language-javascript">const argEntries = Object.entries(args);
+<pre><code class="language-javascript">
 // File: src/index.js
-if (argEntries.length > 0) {
-  const whereClause = `WHERE ${argEntries.map(arg => `${checkoutTableVariablesMap[arg[0]]}=?`).join(' AND ')}`;
-  queryStr = mysqlDataConnector.format(`${queryStr} ${whereClause}`, argEntries.map(arg => arg[1]));
-}</code></pre>
+const resolvers = {
+  Query: {
+    checkouts: async (root, args) => {
+      ...
+      const argEntries = Object.entries(args);
+      if (argEntries.length > 0) {
+        const whereClause = `WHERE ${argEntries.map(arg => `${checkoutTableVariablesMap[arg[0]]}=?`).join(' AND ')}`;
+        queryStr = mysqlDataConnector.format(`${queryStr} ${whereClause}`, argEntries.map(arg => arg[1]));
+      },
+    },
+</code></pre>
 
 ## Retrieve Data and Handle Results
 
@@ -160,8 +173,14 @@ Now, instead of returning the static data, we can return the results or our data
 
 <pre><code class="language-javascript">
 // File: src/index.js
-const queryResults = await mysqlDataConnector.pool.query(queryStr);
-return queryResults;
+const resolvers = {
+  Query: {
+    checkouts: async (root, args) => {
+      ...
+      const queryResults = await mysqlDataConnector.pool.query(queryStr);
+      return queryResults;
+    },
+  },
 </code></pre>
 
 ## Handle Data Type Discrepancies
@@ -198,7 +217,7 @@ has been set up to include more entries than our statically defined data set.
 
 <pre><code class="language-graphql">
 {
-  checkouts (user_email: "dbernath27@jalbum.net") {
+  checkouts (userEmail: "dbernath27@jalbum.net") {
     userEmail
     assetUpc
     checkoutDate


### PR DESCRIPTION
closes #13 

Generate Safe Queries Section
[x] - A code snippet appears as if we should be referencing src/schema/checkout/checkout.model.js but the schema directory doesn’t exist in src yet.
[x] - The code in the step-1 branch has the query and the where clause updates inside the checkouts resolver. We should probably instruct the user to do the same. // File: src/index.js is good but we should tell them where.

Verify GraphQL Query Section
[x] - need to update code snippet query from user_email: to userEmail

***I've opened the PR against the step-1 branch. Please correct this if wrong.