### PR TITLE
step 3 - enhance code snippets and fix grammar

### DIFF
--- a/docs/_pages/3.add-mutations.md
+++ b/docs/_pages/3.add-mutations.md
@@ -39,7 +39,8 @@ fetch in a single action, but MySQL with our driver does not.  Once we have the 
 
 <pre><code class="language-javascript">
 // File: src/schema/checkout/checkout.model.js
-
+import { ApolloError } from 'apollo-server-express';
+...
 const Checkout = {
   ...
     checkoutAsset: async (root, args) => {
@@ -111,6 +112,8 @@ Back in checkout.model.js file we will import our newly exported constants and u
 “isAssetCheckedOut” which gets the current checkout status of the requested asset. If the isAssetCheckedOut method resolves to true.
 
 <pre><code class="language-javascript">
+import { checkoutTableVariablesMap, errors, mappedQueryFields } from './checkout.constants';
+...
 async function isAssetCheckedOut(assetUpc) {
   const isCheckedOutQuery = mysqlDataConnector.format('SELECT count(*) AS row_count FROM checkouts WHERE asset_upc=? and checkin_date IS NULL', assetUpc);
   const isCheckedOutResults = await mysqlDataConnector.pool.query(isCheckedOutQuery);
@@ -164,7 +167,7 @@ export default {
 <br />
 
 For our checkinAsset handler we do much the same as our checkoutAsset handler with the differences being that our check will verify that the asset is currently
-checked out and our database query will be to update and existing row rather than inserting a new one. For our MySQL update, we will run three queries.
+checked out and our database query will be to update an existing row rather than inserting a new one. For our MySQL update, we will run three queries.
   1. Verify asset is checked out and return the `row_id` if it is
   2. Update the database table setting the `checkin_date` for the found `row_id`
   3. Query the database table to get all information for the updated asset and return it to the client


### PR DESCRIPTION
closes #17 

[x] - no mention of importing ApolloError from apollo-server-express. Probably best near this “Back in checkout.model.js file we will import our newly exported constants and update our checkoutAsset function.”
[x] - "Back in checkout.model.js file we will import our newly exported constants and update our checkoutAsset function." Show imports in snippet.
[x] -  grammar error “will verify that the asset is currently checked out and our database query will be to update and existing row” to update an* existing row